### PR TITLE
Dispose `FileStream` before returning from SystemFolder.CreateFileAsync

### DIFF
--- a/src/SystemIO/SystemFolder.cs
+++ b/src/SystemIO/SystemFolder.cs
@@ -221,7 +221,7 @@ public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFas
         if (overwrite)
             File.Delete(newPath);
 
-        File.Create(newPath);
+        File.Create(newPath).Dispose();
         return Task.FromResult<IFile>(new SystemFile(newPath));
     }
 


### PR DESCRIPTION
Closes #2 