### PR TITLE
Switch IAddressableStorable.GetParentAsync to return IFolder

### DIFF
--- a/src/IAddressableStorable.cs
+++ b/src/IAddressableStorable.cs
@@ -16,5 +16,5 @@ public interface IAddressableStorable : IStorable
     /// <summary>
     /// Gets the containing folder for this item, if any.
     /// </summary>
-    public Task<IAddressableFolder?> GetParentAsync(CancellationToken cancellationToken = default); 
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default); 
 }

--- a/src/SystemIO/SystemFile.cs
+++ b/src/SystemIO/SystemFile.cs
@@ -42,8 +42,8 @@ public class SystemFile : IAddressableFile
     }
 
     /// <inheritdoc />
-    public Task<IAddressableFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<IAddressableFolder?>(Directory.GetParent(Path) is { } di ? new SystemFolder(di) : null);
+        return Task.FromResult<IFolder?>(Directory.GetParent(Path) is { } di ? new SystemFolder(di) : null);
     }
 }

--- a/src/SystemIO/SystemFolder.cs
+++ b/src/SystemIO/SystemFolder.cs
@@ -227,9 +227,9 @@ public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFas
     }
 
     /// <inheritdoc />
-    public Task<IAddressableFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<IAddressableFolder?>(Directory.GetParent(Path) is { } di ? new SystemFolder(di) : null);
+        return Task.FromResult<IFolder?>(Directory.GetParent(Path) is { } di ? new SystemFolder(di) : null);
     }
 
     private static bool IsFile(string path) => System.IO.Path.GetFileName(path) is { } str && str != string.Empty && File.Exists(path);


### PR DESCRIPTION
# Overview
This PR changes `IAddressableStorable.GetParentAsync()` to return `IFolder` instead of `IAddressableFolder`. 

Any type of folder can return an addressable folder, so we've made sure the parent of an addressable folder can be any type of folder.

# Background

Discussion pasted from [Discord](https://discord.com/channels/372137812037730304/1005995398894202880/1016493879790424176):

@Arlodotexe:
> Should a Root folder be an IAddressableFolder? 🤔
> I'm implementing addressable folders for Ipfs, and apparently it doesn't need to be.
> A non-addressable folder can return an addressable folder. Which one of those would qualify as the "Root" of any subfolders? 

@yoshiask:
> If I'm understanding the question right, the non-addressable folder should still be the root
> The addressable one has a parent, even if that parent isn't itself addressable

@Arlodotexe
> That's a great point
> This shouldn't create any breaking changes, except for needing to change the declared return type in implementations. I'll update IAddressableStorable.GetParentAsync() to return IFolder? instead of IAddressableFolder? 