### PR TITLE
Added GetFirstItemByNameAsync extension

### DIFF
--- a/src/Archive/ZipArchiveFolder.cs
+++ b/src/Archive/ZipArchiveFolder.cs
@@ -12,7 +12,7 @@ namespace OwlCore.Storage.Archive;
 /// <summary>
 /// A folder implementation wrapping a <see cref="ZipArchive"/>.
 /// </summary>
-public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFolderCanFastGetItem
+public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFolderCanFastGetItem, IFolderCanFastGetItemByName
 {
     /// <summary>
     /// Creates a new instance of <see cref="ZipArchiveFolder"/>.
@@ -177,6 +177,12 @@ public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFo
         }
 
         return item;
+    }
+    
+    /// <inheritdoc/>
+    public async Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return await GetItemAsync(Id + name, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Archive/ZipArchiveFolder.cs
+++ b/src/Archive/ZipArchiveFolder.cs
@@ -12,7 +12,7 @@ namespace OwlCore.Storage.Archive;
 /// <summary>
 /// A folder implementation wrapping a <see cref="ZipArchive"/>.
 /// </summary>
-public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFolderCanFastGetItem, IFolderCanFastGetItemByName
+public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFolderCanFastGetItem, IFolderCanFastGetFirstItemByName
 {
     /// <summary>
     /// Creates a new instance of <see cref="ZipArchiveFolder"/>.
@@ -180,7 +180,7 @@ public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder, IFo
     }
     
     /// <inheritdoc/>
-    public async Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default)
+    public async Task<IAddressableStorable> GetFirstItemByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         return await GetItemAsync(Id + name, cancellationToken);
     }

--- a/src/Extensions/FolderExtensions.cs
+++ b/src/Extensions/FolderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -43,6 +44,27 @@ public static class FolderExtensions
         var targetItem = await folder.GetItemsAsync(cancellationToken: cancellationToken).FirstOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
         if (targetItem is null)
             throw new FileNotFoundException($"No storage item with the ID \"{id}\" could be found.");
+
+        return targetItem;
+    }
+    
+    /// <summary>
+    /// Retrieves the <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
+    /// </summary>
+    /// <param name="folder">The folder to get items from.</param>
+    /// <param name="name">The <see cref="IStorable.Name"/> of the storable item to retrieve.</param>
+    /// <param name="cancellationToken">The cancellation token to observe.</param>
+    /// <returns>An async enumerable which yields the items in the provided folder.</returns>
+    /// <exception cref="FileNotFoundException">The item was not found in the provided folder.</exception>
+    public static async Task<IAddressableStorable> GetItemByNameAsync(this IFolder folder, string name, CancellationToken cancellationToken = default)
+    {
+        if (folder is IFolderCanFastGetItemByName fastPath)
+            return await fastPath.GetItemByNameAsync(name, cancellationToken);
+
+        var targetItem = await folder.GetItemsAsync(cancellationToken: cancellationToken)
+            .FirstOrDefaultAsync(x => name.Equals(x.Name, StringComparison.Ordinal), cancellationToken: cancellationToken);
+        if (targetItem is null)
+            throw new FileNotFoundException($"No storage item with the name \"{name}\" could be found.");
 
         return targetItem;
     }

--- a/src/Extensions/FolderExtensions.cs
+++ b/src/Extensions/FolderExtensions.cs
@@ -49,17 +49,17 @@ public static class FolderExtensions
     }
     
     /// <summary>
-    /// Retrieves the <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
+    /// Retrieves the first <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
     /// </summary>
     /// <param name="folder">The folder to get items from.</param>
     /// <param name="name">The <see cref="IStorable.Name"/> of the storable item to retrieve.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns>An async enumerable which yields the items in the provided folder.</returns>
     /// <exception cref="FileNotFoundException">The item was not found in the provided folder.</exception>
-    public static async Task<IAddressableStorable> GetItemByNameAsync(this IFolder folder, string name, CancellationToken cancellationToken = default)
+    public static async Task<IAddressableStorable> GetFirstItemByNameAsync(this IFolder folder, string name, CancellationToken cancellationToken = default)
     {
-        if (folder is IFolderCanFastGetItemByName fastPath)
-            return await fastPath.GetItemByNameAsync(name, cancellationToken);
+        if (folder is IFolderCanFastGetFirstItemByName fastPath)
+            return await fastPath.GetFirstItemByNameAsync(name, cancellationToken);
 
         var targetItem = await folder.GetItemsAsync(cancellationToken: cancellationToken)
             .FirstOrDefaultAsync(x => name.Equals(x.Name, StringComparison.Ordinal), cancellationToken: cancellationToken);

--- a/src/Extensions/IFolderCanFastGetFirstItemByName.cs
+++ b/src/Extensions/IFolderCanFastGetFirstItemByName.cs
@@ -5,16 +5,16 @@ using System.Threading.Tasks;
 namespace OwlCore.Storage;
 
 /// <summary>
-/// Provides a fast-path for the <see cref="FolderExtensions.GetItemByNameAsync"/> extension method.
+/// Provides a fast-path for the <see cref="FolderExtensions.GetFirstItemByNameAsync"/> extension method.
 /// </summary>
 /// <exception cref="FileNotFoundException">The item was not found in the provided folder.</exception>
-public interface IFolderCanFastGetItemByName : IFolder
+public interface IFolderCanFastGetFirstItemByName : IFolder
 {
     /// <summary>
-    /// Retrieves the <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
+    /// Retrieves the first <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
     /// </summary>
     /// <param name="name">The <see cref="IStorable.Name"/> of the storable item to retrieve.</param>
     /// <param name="cancellationToken">The cancellation token to observe.</param>
     /// <returns></returns>
-    public Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IAddressableStorable> GetFirstItemByNameAsync(string name, CancellationToken cancellationToken = default);
 }

--- a/src/Extensions/IFolderCanFastGetItemByName.cs
+++ b/src/Extensions/IFolderCanFastGetItemByName.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// Provides a fast-path for the <see cref="FolderExtensions.GetItemByNameAsync"/> extension method.
+/// </summary>
+/// <exception cref="FileNotFoundException">The item was not found in the provided folder.</exception>
+public interface IFolderCanFastGetItemByName : IFolder
+{
+    /// <summary>
+    /// Retrieves the <see cref="IStorable"/> item which has the provided <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The <see cref="IStorable.Name"/> of the storable item to retrieve.</param>
+    /// <param name="cancellationToken">The cancellation token to observe.</param>
+    /// <returns></returns>
+    public Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default);
+}

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.6.1</Version>
+		<Version>0.7.0</Version>
 		<Product>OwlCore</Product>
 		<Description>Coordinated, high-latency IPoAC == A bad hard drive comprised entirely of Owls (see rfc6214)
 		
@@ -23,6 +23,10 @@
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageReleaseNotes>
+--- 0.7.0 ---
+[New]
+Added IFolder.GetFirstItemByNameAsync and IFolderCanFastGetFirstItemByName, a folder extension to simplify the retrieval of items by name rather than ID. Contributed by @yoshiask@github.com.
+
 --- 0.6.1 ---
 [Fixes]
 Removed leading separator in ZIP archive IDs. Contributed by @yoshiask@github.com.

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -25,7 +25,7 @@
 		<PackageReleaseNotes>
 --- 0.7.0 ---
 [New]
-Added IFolder.GetFirstItemByNameAsync and IFolderCanFastGetFirstItemByName, a folder extension to simplify the retrieval of items by name rather than ID. Contributed by @yoshiask@github.com.
+Added the IFolder.GetFirstItemByNameAsync extension method and the IFolderCanFastGetFirstItemByName interface. Contributed by @yoshiask@github.com.
 
 --- 0.6.1 ---
 [Fixes]

--- a/src/SystemIO/SystemFolder.cs
+++ b/src/SystemIO/SystemFolder.cs
@@ -12,7 +12,7 @@ namespace OwlCore.Storage.SystemIO;
 /// <summary>
 /// An <see cref="IFolder"/> implementation that uses System.IO.
 /// </summary>
-public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFastGetItem, IFolderCanFastGetItemByName
+public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFastGetItem, IFolderCanFastGetFirstItemByName
 {
     /// <summary>
     /// Creates a new instance of <see cref="SystemFolder"/>.
@@ -132,7 +132,7 @@ public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFas
     }
 
     /// <inheritdoc/>
-    public async Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default)
+    public async Task<IAddressableStorable> GetFirstItemByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         return await GetItemAsync(System.IO.Path.Combine(Path, name), cancellationToken);
     }

--- a/src/SystemIO/SystemFolder.cs
+++ b/src/SystemIO/SystemFolder.cs
@@ -12,7 +12,7 @@ namespace OwlCore.Storage.SystemIO;
 /// <summary>
 /// An <see cref="IFolder"/> implementation that uses System.IO.
 /// </summary>
-public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFastGetItem
+public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFastGetItem, IFolderCanFastGetItemByName
 {
     /// <summary>
     /// Creates a new instance of <see cref="SystemFolder"/>.
@@ -129,6 +129,12 @@ public class SystemFolder : IModifiableFolder, IAddressableFolder, IFolderCanFas
         }
 
         throw new ArgumentException($"Could not determine if the provided path is a file or folder. Path: {id}");
+    }
+
+    /// <inheritdoc/>
+    public async Task<IAddressableStorable> GetItemByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return await GetItemAsync(System.IO.Path.Combine(Path, name), cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This extension allows consumers to get items from a folder using only the item's name. This prevents situations where the consumer has to be aware of the implementation details of a specific `IFolder`'s IDs, for example when attempting to get an item in a known location without having previously requested the item.