### PR TITLE
Fixed a bug where ZipArchiveFolder would fail to find folders by name

### DIFF
--- a/src/Archive/ReadOnlyZipArchiveFolder.cs
+++ b/src/Archive/ReadOnlyZipArchiveFolder.cs
@@ -162,14 +162,21 @@ public class ReadOnlyZipArchiveFolder : IChildFolder, IFastGetRoot, IFastGetItem
         else
         {
             // Get folder
-            item = GetVirtualFolders()[id];
+            string subfolderId = NormalizeEnding(id);
+            var virtualFolders = GetVirtualFolders();
+            
+            if (!virtualFolders.TryGetValue(subfolderId, out var subfolder))
+                throw new FileNotFoundException($"No item with ID '{id}' or '{subfolderId}' exists in '{Id}'.");
+            
+            item = subfolder;
         }
 
         return item;
     }
     
     /// <inheritdoc/>
-    public async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = default) => await GetItemAsync(Id + name, cancellationToken);
+    public async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = default)
+        => await GetItemAsync(Id + name, cancellationToken);
 
     /// <inheritdoc/>
     public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Closes #21

# Summary
This PR makes sure in `ReadOnlyZipArchiveFolder`, the ID used to get a folder in `GetItemAsync` always ends in a trailing slash, since that's the folder ID format (which is also used at the virtual folder key).

Note that simply doing `$"{Id}{name}{ZIP_DIRECTORY_SEPARATOR}"` in `GetFirstByNameAsync` would fix folders but would break fetching files by name.