### PR TITLE
Removed default FileAccess.Read parameter for IFile.OpenStreamAsync

### DIFF
--- a/src/Extensions/CopyAndMoveExtensions.cs
+++ b/src/Extensions/CopyAndMoveExtensions.cs
@@ -41,7 +41,7 @@ public static partial class ModifiableFolderExtensions
         }
 
         // Open the source file
-        using var sourceStream = await fileToCopy.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var sourceStream = await fileToCopy.OpenStreamAsync(FileAccess.Read, cancellationToken: cancellationToken);
 
         // Create the destination file
         var newFile = await destinationFolder.CreateFileAsync(fileToCopy.Name, overwrite, cancellationToken);

--- a/src/Extensions/FileOpenExtensions.cs
+++ b/src/Extensions/FileOpenExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IFile"/>.
+/// </summary>
+public static partial class FileExtensions
+{
+    /// <summary>
+    /// Opens the file for reading.
+    /// </summary>
+    /// <param name="file">The file to open.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A task containing the requested stream.</returns>
+    public static Task<Stream> OpenReadAsync(this IFile file, CancellationToken cancellationToken = default) => file.OpenStreamAsync(FileAccess.Read, cancellationToken);
+    
+    /// <summary>
+    /// Opens the file for writing.
+    /// </summary>
+    /// <param name="file">The file to open.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A task containing the requested stream.</returns>
+    public static Task<Stream> OpenWriteAsync(this IFile file, CancellationToken cancellationToken = default) => file.OpenStreamAsync(FileAccess.Write, cancellationToken);
+    
+    /// <summary>
+    /// Opens the file for reading and writing.
+    /// </summary>
+    /// <param name="file">The file to open.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A task containing the requested stream.</returns>
+    public static Task<Stream> OpenReadWriteAsync(this IFile file, CancellationToken cancellationToken = default) => file.OpenStreamAsync(FileAccess.ReadWrite, cancellationToken);
+}

--- a/src/IFile.cs
+++ b/src/IFile.cs
@@ -15,5 +15,5 @@ public interface IFile : IStorable
     /// <param name="accessMode">A <see cref="FileAccess"/> value that specifies the operations that can be performed on the file.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A stream that provides access to this file, with the specified <paramref name="accessMode"/>.</returns>
-    Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default);
+    Task<Stream> OpenStreamAsync(FileAccess accessMode, CancellationToken cancellationToken = default);
 }

--- a/src/Memory/MemoryFolder.cs
+++ b/src/Memory/MemoryFolder.cs
@@ -93,7 +93,7 @@ public class MemoryFolder : IModifiableFolder, IChildFolder, IFastGetItem
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        using var stream = await fileToCopy.OpenStreamAsync(cancellationToken: cancellationToken);
+        using var stream = await fileToCopy.OpenStreamAsync(FileAccess.Read, cancellationToken: cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (stream.CanSeek)

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -23,6 +23,16 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.10.0 ---
+THIS IS A BREAKING RELEASE
+Update asap, and do not use older versions or implementations.
+
+[Breaking]
+The default FileAccess.Read parameter for IFile.OpenStreamAsync has been removed. This is primarily to avoid confusion about why the default returned stream can't be written to, but follows the concept that simply opening a stream implies nothing about read/write preferences for that resource, so no default value should be used.
+
+[New]
+Extensions methods for IFile.OpenReadAsync, IFile.OpenWriteAsync and IFile.OpenReadWriteAsync have been added.
+
 --- 0.9.3 ---
 [Improvements]
 The DirectoryInfo for SystemFolder is now exposed as a public Info property.


### PR DESCRIPTION
This PR closes #42. 

## Breaking
The default FileAccess.Read parameter for IFile.OpenStreamAsync has been removed. This is primarily to avoid confusion about why the default returned stream can't be written to, but follows the concept that simply opening a stream implies nothing about read/write preferences for that resource, so no default value should be used.

## New
Extensions methods for IFile.OpenReadAsync, IFile.OpenWriteAsync and IFile.OpenReadWriteAsync have been added.
