### PR TITLE
Fixed file handling on ZipArchiveFolder.DeleteAsync

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		
@@ -23,6 +23,13 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.10.1 ---
+[Fixes]
+Fixed an issue where ZipArchiveFolder.DeleteAsync wasn't handling files correctly.
+
+[Improvements]
+Update all dependencies to latest versions.
+
 --- 0.10.0 ---
 THIS IS A BREAKING RELEASE
 Update asap, and do not use older versions or implementations.
@@ -254,9 +261,9 @@ Initial release of OwlCore.Storage.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.13.1">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/System/IO/Compression/ZipArchiveFolder.cs
+++ b/src/System/IO/Compression/ZipArchiveFolder.cs
@@ -119,8 +119,20 @@ public class ZipArchiveFolder : ReadOnlyZipArchiveFolder, IModifiableFolder
 
             if (entry is null)
                 throw new FileNotFoundException("The item was not found in the folder.");
+
+            entry.Delete();
+        }
+        else if (item is ZipArchiveEntryFile file)
+        {
+            var entry = TryGetEntry(file.Name);
+            if (entry is null)
+                throw new FileNotFoundException("The item was not found in the folder.");
             else
                 entry.Delete();
+        }
+        else
+        {
+            throw new ArgumentException("The item is not a valid child of this folder.", nameof(item));
         }
     }
 

--- a/tests/OwlCore.Storage.Tests/OwlCore.Storage.Tests.csproj
+++ b/tests/OwlCore.Storage.Tests/OwlCore.Storage.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.TestPlatform" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.0" />
+    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.1" />
     <ProjectReference Include="..\..\src\OwlCore.Storage.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR fixes an issue found by the CommonTests during a routine dependency update. 