### PR TITLE
Update SystemFolderWatcher

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		
@@ -23,6 +23,10 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.11.1 ---
+[Fixes
+Fixed an issue where SystemFolderWatcher would not capture any file system events.
+		
 --- 0.11.0 ---
 [New]
 Added new FileReadExtensions and FileWriteExtensions for reading and writing IFile as text content or byte arrays.

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -24,7 +24,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
 --- 0.11.1 ---
-[Fixes
+[Fixes]
 Fixed an issue where SystemFolderWatcher would not capture any file system events.
 		
 --- 0.11.0 ---

--- a/src/System/IO/SystemFolderWatcher.cs
+++ b/src/System/IO/SystemFolderWatcher.cs
@@ -119,7 +119,8 @@ namespace OwlCore.Storage.System.IO
                 return new SystemFile(path);
             }
 
-            throw new ArgumentException($"Could not determine if the path '{path}' is a file or folder.");
+            // The item is most likely deleted. Return all available information through SimpleStorableItem
+            return new SimpleStorableItem(id: path, name: Path.GetFileName(path));
         }
 
         private static bool IsFile(string path) => Path.GetFileName(path) is { } str && str != string.Empty && File.Exists(path);

--- a/tests/OwlCore.Storage.Tests/SystemIO/IFolderTests.cs
+++ b/tests/OwlCore.Storage.Tests/SystemIO/IFolderTests.cs
@@ -16,7 +16,7 @@ public class IFolderTests : CommonIModifiableFolderTests
     public override Task<IModifiableFolder> CreateModifiableFolderWithItems(int fileCount, int folderCount)
     {
         var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        var dir = Directory.CreateDirectory(tempFolder);
+        _ = Directory.CreateDirectory(tempFolder);
 
         for (var i = 0; i < fileCount; i++)
         {

--- a/tests/OwlCore.Storage.Tests/SystemIO/IFolderTests.cs
+++ b/tests/OwlCore.Storage.Tests/SystemIO/IFolderTests.cs
@@ -48,6 +48,8 @@ public class IFolderTests : CommonIModifiableFolderTests
         
         await folder.CreateFileAsync(GetHashCode().ToString(), overwrite: true);
 
+        // Await a small delay before asserting
+        await Task.Delay(2000);
         Assert.IsTrue(collectionChanged, "CollectionChanged was not raised on file create");
     }
 
@@ -61,7 +63,9 @@ public class IFolderTests : CommonIModifiableFolderTests
         watcher.CollectionChanged += (sender, args) => collectionChanged = true;
 
         await folder.CreateFolderAsync(GetHashCode().ToString(), overwrite: true);
-
+        
+        // Await a small delay before asserting
+        await Task.Delay(2000);
         Assert.IsTrue(collectionChanged, "CollectionChanged was not raised on folder create");
     }
 
@@ -77,6 +81,8 @@ public class IFolderTests : CommonIModifiableFolderTests
 
         await folder.DeleteAsync(existingItem);
 
+        // Await a small delay before asserting
+        await Task.Delay(2000);
         Assert.IsTrue(collectionChanged, "CollectionChanged was not raised on delete");
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the `SystemFolderWatcher` implementation where the underlying .NET's `FileSystemWatcher` did not enable raising events.

This critical bug prevented capturing any file system events whatsoever.