### PR TITLE
Enforced async I/O when opening a SystemFile

### DIFF
--- a/src/System/IO/SystemFile.cs
+++ b/src/System/IO/SystemFile.cs
@@ -68,7 +68,7 @@ public class SystemFile : IChildFile, IGetRoot
     /// <inheritdoc />
     public Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
     {
-        var stream = File.Open(Path, FileMode.Open, accessMode);
+        var stream = new FileStream(Path, FileMode.Open, accessMode, FileShare.None, 4096, FileOptions.Asynchronous);
         cancellationToken.ThrowIfCancellationRequested();
 
         return Task.FromResult<Stream>(stream);


### PR DESCRIPTION
By default, the stream returned from `File.Open` does synchronous operations on the file. We can make the underlying operating system give us an asynchronous file stream to do true async reads/writes.