### PR TITLE
Bump version to 0.11.3 with performance improvement notes

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.11.2</Version>
+    <Version>0.11.3</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		
@@ -23,6 +23,10 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.11.3 ---
+[Improvement]
+Removed redundant validation when enumerating files and folders to improve performance in SystemFile and SystemFolder.
+
 --- 0.11.2 ---
 [Fixes]
 Fixed an issue where the stream returned from `File.Open` does synchronous operations on the file and didn't support cancellation during read/write. The underlying operating system now gives us an asynchronous file stream to do true async reads/writes.


### PR DESCRIPTION
Updates the version and adds release notes for a performance improvement in `OwlCore.Storage.csproj`.

- **Version Bumped**: Updates the `<Version>` tag from `0.11.2` to `0.11.3`.
- **Release Notes Added**: Introduces a new entry under `<PackageReleaseNotes>` to document the removal of redundant validation when enumerating files and folders, marked as an [Improvement].


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arlodotexe/OwlCore.Storage?shareId=2def5dd9-a576-4335-b628-8c0fb4f5e559).