### PR TITLE
Fixed Stream.Position not being reset

### DIFF
--- a/src/Memory/MemoryFile.cs
+++ b/src/Memory/MemoryFile.cs
@@ -56,6 +56,9 @@ namespace OwlCore.Storage.Memory
             if (accessMode == 0)
                 throw new ArgumentOutOfRangeException(nameof(accessMode), $"{nameof(FileAccess)}.{accessMode} is not valid here.");
 
+            // The consumer expects that whenever opening a Stream instance the Position is set to the beginning of the stream.
+            _memoryStream.Position = 0L;
+
             return Task.FromResult<Stream>(new NonDisposableStreamWrapper(_memoryStream));
         }
     }

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		


### PR DESCRIPTION
### Summary
This PR fixes an issue where reopening a sought/written to `Stream` opened on `MemoryFile` did not have its position reset.

### Rationale
It is most common that virtually every method that opens a stream to a resource sets the stream pointer to the beginning. The only exception that may overrule this is when opening a new FileStream with the `FileMode.Append` flag. Any other behavior is thus erroneous.
