### PR TITLE
Bump version number to 0.12.0

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.11.3</Version>
+    <Version>0.12.0</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		


### PR DESCRIPTION
Bump version number to 0.12.0

* Update the `<Version>` element in `src/OwlCore.Storage.csproj` to `0.12.0`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arlodotexe/OwlCore.Storage?shareId=2ae33d5a-3eb0-42da-87a5-9a2e8ddcd0ed).