### PR TITLE
Release 0.12.1

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.12.0</Version>
+    <Version>0.12.1</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		
@@ -23,6 +23,11 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.12.1 ---
+[Improvements]
+Added the `virtual` keyword to all methods in `SystemFile` and `SystemFolder`, allowing consumers to extend these or adjust these methods in a custom derived implementation. 8d176f915ba2adb525f6aae4e40fa3f06944f0b9
+SystemFile.FileShare and SystemFile.BufferSize properties for `FileStream` constructor parameters that were previously hardcoded. fe2205fe308df185411243b1c77bffa09e876f76
+
 --- 0.12.0 ---
 [Breaking]
 The Stream opened from HttpFile is no longer seekable, as the internal LazySeekStream and all usages have been removed.


### PR DESCRIPTION
[Improvements]
8d176f915ba2adb525f6aae4e40fa3f06944f0b9 https://github.com/Arlodotexe/OwlCore.Storage/pull/79 Added the `virtual` keyword to all methods in `SystemFile` and `SystemFolder`, allowing consumers to extend these or adjust these methods in a custom derived implementation. 

fe2205fe308df185411243b1c77bffa09e876f76 https://github.com/Arlodotexe/OwlCore.Storage/pull/79 Added SystemFile.FileShare and SystemFile.BufferSize properties for `FileStream` constructor parameters that were previously hardcoded. 