### PR TITLE
Fixed move-based renaming when using fallback code

### DIFF
--- a/src/Extensions/MoveExtensions.cs
+++ b/src/Extensions/MoveExtensions.cs
@@ -75,7 +75,7 @@ public static partial class ModifiableFolderExtensions
             return await fastPath.MoveFromAsync(fileToMove, source, overwrite, newName, cancellationToken, fallback: MoveFromFallbackAsync);
 
         // Manual move. Slower, but covers all scenarios.
-        return await MoveFromFallbackAsync(destinationFolder, fileToMove, source, overwrite, cancellationToken);
+        return await MoveFromFallbackAsync(destinationFolder, fileToMove, source, overwrite, newName, cancellationToken);
     }
 
     private static async Task<IChildFile> MoveFromFallbackAsync(IModifiableFolder destinationFolder, IChildFile fileToMove, IModifiableFolder source, bool overwrite, CancellationToken cancellationToken = default)

--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -17,7 +17,7 @@
     <DebugType>embedded</DebugType>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.13.0</Version>
+    <Version>0.13.1</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the Windows App Community.
 		
@@ -26,6 +26,10 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.13.1 ---
+[Fixes]
+Fixed the MoveFromAsync rename-capable extension not calling the proper rename-capable fallback overload.
+
 --- 0.13.0 ---
 [New]
 Added new ICreateRenamedCopy and IMoveRenamedFrom extension method overloads and corresponding extension method interfaces for ICreateCopy and IMoveFrom.


### PR DESCRIPTION
This PR:

* **Fixed the MoveFromAsync rename-capable extension not calling the proper rename-capable fallback overload.**
* **Version bump to 0.13.1, add release notes.**
