### PR TITLE
Add DFS/BFS traversal, override/composite folders, truncation

### DIFF
--- a/src/BreadthFirstRecursiveFolder.cs
+++ b/src/BreadthFirstRecursiveFolder.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// A wrapper around an <see cref="IFolder"/> that provides breadth-first recursive iteration through all child items.
+/// This class traverses an entire folder hierarchy using a breadth-first search algorithm.
+/// </summary>
+public class BreadthFirstRecursiveFolder : IFolder
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadthFirstRecursiveFolder"/> class.
+    /// </summary>
+    /// <param name="rootFolder">The root folder to recursively iterate through.</param>
+    public BreadthFirstRecursiveFolder(IFolder rootFolder)
+    {
+        RootFolder = rootFolder;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier of the root folder.
+    /// </summary>
+    public string Id => RootFolder.Id;
+
+    /// <summary>
+    /// Gets the name of the root folder.
+    /// </summary>
+    public string Name => RootFolder.Name;
+
+    /// <summary>
+    /// Gets the root folder that this instance will recursively iterate through.
+    /// </summary>
+    public IFolder RootFolder { get; }
+
+    /// <summary>
+    /// Gets or initializes the maximum depth for recursive folder traversal.
+    /// When null, there is no depth limit. When set to a value, traversal will stop before exceeding that depth level.
+    /// Depth is measured such that the direct children of the root are at depth 1.
+    /// </summary>
+    public int? MaxDepth { get; init; }
+
+    /// <summary>
+    /// Asynchronously enumerates through all items in the folder hierarchy using breadth-first search.
+    /// This method traverses through each level of subfolders and returns items that match the specified type filter.
+    /// </summary>
+    /// <param name="type">The type of items to return. Use <see cref="StorableType.All"/> to return all items,
+    /// <see cref="StorableType.File"/> to return only files, or <see cref="StorableType.Folder"/> to return only folders.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the enumeration operation.</param>
+    /// <returns>An async enumerable of <see cref="IStorableChild"/> items found during the breadth-first traversal.</returns>
+    /// <remarks>
+    /// The traversal uses a queue-based approach to implement breadth-first search without recursion.
+    /// Items are yielded in level order: first all direct children of the root, then children of those folders, and so on.
+    /// If <see cref="MaxDepth"/> is set, the traversal will not exceed that depth level.
+    /// </remarks>
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(
+        StorableType type = StorableType.All,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // BFS folder iteration using a queue of enumerators with depth tracking
+        var queue = new Queue<(IAsyncEnumerator<IStorableChild> Enumerator, int Depth)>();
+
+        try
+        {
+            // Depth 1 = direct children of root
+            queue.Enqueue((RootFolder.GetItemsAsync(StorableType.All, cancellationToken).GetAsyncEnumerator(cancellationToken), 1));
+
+            while (queue.Count > 0)
+            {
+                var (currentEnumerator, currentDepth) = queue.Peek();
+
+                if (await currentEnumerator.MoveNextAsync())
+                {
+                    var item = currentEnumerator.Current;
+
+                    // Filter by type if needed
+                    if (type == StorableType.All ||
+                        (type == StorableType.File && item is IFile) ||
+                        (type == StorableType.Folder && item is IFolder))
+                    {
+                        yield return item;
+                    }
+
+                    // If it's a folder and we haven't reached max depth, enqueue its children
+                    if (item is IFolder folder)
+                    {
+                        if (MaxDepth is null || currentDepth < MaxDepth)
+                        {
+                            queue.Enqueue((folder.GetItemsAsync(StorableType.All, cancellationToken).GetAsyncEnumerator(cancellationToken), currentDepth + 1));
+                        }
+                    }
+                }
+                else
+                {
+                    // Current enumerator is exhausted, dispose and remove it
+                    await currentEnumerator.DisposeAsync();
+                    queue.Dequeue();
+                }
+            }
+        }
+        finally
+        {
+            // Dispose all remaining enumerators
+            while (queue.Count > 0)
+            {
+                var (enumerator, _) = queue.Dequeue();
+                await enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/DepthFirstRecursiveFolder.cs
+++ b/src/DepthFirstRecursiveFolder.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// A wrapper around an <see cref="IFolder"/> that provides depth-first recursive iteration through all child items.
+/// This class allows traversal of an entire folder hierarchy using depth-first search algorithm.
+/// </summary>
+public class DepthFirstRecursiveFolder : IFolder
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DepthFirstRecursiveFolder"/> class.
+    /// </summary>
+    /// <param name="rootFolder">The root folder to recursively iterate through.</param>
+    public DepthFirstRecursiveFolder(IFolder rootFolder)
+    {
+        RootFolder = rootFolder;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier of the root folder.
+    /// </summary>
+    public string Id => RootFolder.Id;
+
+    /// <summary>
+    /// Gets the name of the root folder.
+    /// </summary>
+    public string Name => RootFolder.Name;
+
+    /// <summary>
+    /// Gets the root folder that this instance will recursively iterate through.
+    /// </summary>
+    public IFolder RootFolder { get; }
+
+    /// <summary>
+    /// Gets or initializes the maximum depth for recursive folder traversal.
+    /// When null, there is no depth limit. When set to a value, recursion will stop at that depth level.
+    /// </summary>
+    public int? MaxDepth { get; init; }
+
+    /// <summary>
+    /// Asynchronously enumerates through all items in the folder hierarchy using depth-first search.
+    /// This method recursively traverses through all subfolders and returns items that match the specified type filter.
+    /// </summary>
+    /// <param name="type">The type of items to return. Use <see cref="StorableType.All"/> to return all items,
+    /// <see cref="StorableType.File"/> to return only files, or <see cref="StorableType.Folder"/> to return only folders.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the enumeration operation.</param>
+    /// <returns>An async enumerable of <see cref="IStorableChild"/> items found during the depth-first traversal.</returns>
+    /// <remarks>
+    /// The traversal uses a stack-based approach to implement depth-first search without recursion.
+    /// Items are yielded in the order they are discovered during the depth-first traversal.
+    /// If <see cref="MaxDepth"/> is set, the traversal will not exceed that depth level.
+    /// </remarks>
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // DFS folder iteration using a stack of enumerators
+        var ongoing = new Stack<IAsyncEnumerator<IStorableChild>>();
+
+        try
+        {
+            // Start with the root folder
+            ongoing.Push(RootFolder.GetItemsAsync(StorableType.All, cancellationToken).GetAsyncEnumerator(cancellationToken));
+
+            while (ongoing.Count > 0)
+            {
+                var currentEnumerator = ongoing.Peek();
+
+                // Try to get the next item from current enumerator
+                if (await currentEnumerator.MoveNextAsync())
+                {
+                    var item = currentEnumerator.Current;
+
+                    // Filter by type if needed
+                    if (type == StorableType.All ||
+                        (type == StorableType.File && item is IFile) ||
+                        (type == StorableType.Folder && item is IFolder))
+                    {
+                        yield return item;
+                    }
+
+                    // If it's a folder and we haven't reached max depth, add it to the stack
+                    if (item is IFolder folder)
+                    {
+                        if (MaxDepth is null || ongoing.Count < MaxDepth)
+                            ongoing.Push(folder.GetItemsAsync(StorableType.All, cancellationToken).GetAsyncEnumerator(cancellationToken));
+                    }
+                }
+                else
+                {
+                    // Current enumerator is exhausted, dispose and remove it
+                    await currentEnumerator.DisposeAsync();
+                    ongoing.Pop();
+                }
+            }
+        }
+        finally
+        {
+            // Dispose all remaining enumerators
+            while (ongoing.Count > 0)
+            {
+                await ongoing.Pop().DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/ItemsOverrideFolder.cs
+++ b/src/ItemsOverrideFolder.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// Overrides the return value for the given folder's <see cref="IFolder.GetItemsAsync(StorableType, CancellationToken)"/> async enumerable.
+/// </summary>
+/// <param name="Folder">The folder being overridden.</param>
+/// <param name="ItemsOverrideFunc">The function used to override the items yielded by <see cref="GetItemsAsync"/>.</param>
+public class ItemsOverrideFolder(IFolder Folder, Func<IAsyncEnumerable<IStorableChild>, IAsyncEnumerable<IStorableChild>> ItemsOverrideFunc) : IFolder
+{
+    /// <summary>
+    /// The folder being overridden
+    /// </summary>
+    public IFolder Folder { get; } = Folder;
+
+    /// <summary>
+    /// The function used to override the items yielded by <see cref="GetItemsAsync"/>. 
+    /// </summary>
+    public Func<IAsyncEnumerable<IStorableChild>, IAsyncEnumerable<IStorableChild>> ItemsOverrideFunc { get; } = ItemsOverrideFunc;
+
+    /// <inheritdoc/>
+    public string Id => Folder.Id;
+
+    /// <inheritdoc/>
+    public string Name => Folder.Name;
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, CancellationToken cancellationToken = default)
+    {
+        return ItemsOverrideFunc(Folder.GetItemsAsync(type, cancellationToken));
+    }
+}

--- a/src/ParentOverrideChildFile.cs
+++ b/src/ParentOverrideChildFile.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Storage;
+
+namespace OwlCore.Console.Storage;
+
+/// <summary>
+/// An <see cref="IChildFile"/> wrapper that gives a custom parent to any <see cref="IFile"/>.
+/// </summary>
+public class ParentOverrideChildFile : IChildFile
+{
+    /// <inheritdoc />
+    public required IFile Inner { get; init; }
+
+    /// <summary>
+    /// The custom parent for this file.
+    /// </summary>
+    public required IFolder? Parent { get; init; }
+
+    /// <inheritdoc />
+    public string Id => Inner.Id;
+
+    /// <inheritdoc />
+    public string Name => Inner.Name;
+
+    /// <inheritdoc />
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default) => Task.FromResult(Parent);
+
+    /// <inheritdoc />
+    public Task<Stream> OpenStreamAsync(FileAccess accessMode, CancellationToken cancellationToken = default) => Inner.OpenStreamAsync(accessMode, cancellationToken);
+}

--- a/src/ReadOnlyCompositeFolder.cs
+++ b/src/ReadOnlyCompositeFolder.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Storage;
+
+namespace OwlCore.Console.Storage;
+
+/// <summary>
+/// Enables building a folder from an arbitrary list of files.
+/// </summary>
+public class ReadOnlyCompositeFolder : IFolder
+{
+    /// <inheritdoc />
+    public required string Id { get; init; }
+
+    /// <inheritdoc />
+    public required string Name { get; init; }
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        // Ensure asynchronous execution to avoid CS1998 and respect cancellation
+        await Task.Yield();
+
+        foreach (var file in Sources.ToArray())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            yield return new ParentOverrideChildFile
+            {
+                Inner = file,
+                Parent = this,
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public ICollection<IFile> Sources { get; init; } = [];
+}

--- a/src/TruncatedFile.cs
+++ b/src/TruncatedFile.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// A file wrapper that limits the underlying stream to a given length.
+/// </summary>
+/// <param name="File">The file to wrap.</param>
+/// <param name="MaxLength">The maximum byte length for this file.</param>
+public class TruncatedFile(IFile File, long MaxLength) : IFile
+{
+    /// <summary>
+    /// The file to wrap.
+    /// </summary>
+    public IFile File { get; } = File;
+
+    /// <summary>
+    /// The maximum byte length for this file.
+    /// </summary>
+    public long MaxLength { get; set; } = MaxLength;
+
+    /// <inheritdoc/>
+    public string Id => File.Id;
+
+    /// <inheritdoc/>
+    public string Name => File.Name;
+
+    /// <inheritdoc/>
+    public async Task<Stream> OpenStreamAsync(FileAccess accessMode, CancellationToken cancellationToken = default)
+    {
+        var fileStream = await File.OpenStreamAsync(accessMode, cancellationToken);
+        return new TruncatedStream(fileStream, MaxLength);
+    }
+}

--- a/src/TruncatedFileSizeFolder.cs
+++ b/src/TruncatedFileSizeFolder.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using OwlCore.Console.Storage;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// A folder that limits each file to a given byte length. 
+/// </summary>
+/// <param name="Folder"></param>
+/// <param name="MaxFileLength"></param>
+public class TruncatedFilesFolder(IFolder Folder, int MaxFileLength) : IFolder
+{
+    /// <summary>
+    /// The wrapped folder.
+    /// </summary>
+    public IFolder Folder { get; } = Folder;
+
+    /// <summary>
+    /// The max byte length for the files in this folder.
+    /// </summary>
+    public int MaxFileLength { get; } = MaxFileLength;
+
+    /// <inheritdoc/>
+    public string Id => Folder.Id;
+
+    /// <inheritdoc/>
+    public string Name => Folder.Name;
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in Folder.GetItemsAsync(type, cancellationToken))
+        {
+            if (item is IChildFile file)
+            {
+                yield return new ParentOverrideChildFile()
+                {
+                    Inner = new TruncatedFile(file, MaxFileLength),
+                    Parent = await file.GetParentAsync(cancellationToken),
+                };
+            }
+            else
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/src/TruncatedStream.cs
+++ b/src/TruncatedStream.cs
@@ -1,0 +1,105 @@
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage;
+
+/// <summary>
+/// A stream wrapper that limits the number of bytes that can be read or written.
+/// </summary>
+/// <param name="Stream">The underlying stream to wrap around.</param>
+/// <param name="MaxLength">The maximum length for this stream</param>
+public class TruncatedStream(Stream Stream, long MaxLength) : Stream, IAsyncDisposable
+{
+    private long _position;
+
+    /// <summary>
+    /// The max length to read from the underlying <see cref="Stream"/>.
+    /// </summary>
+    public long MaxLength { get; set; } = MaxLength;
+
+    /// <summary>
+    /// The underlying stream to read from.
+    /// </summary>
+    public Stream Stream { get; } = Stream;
+
+    /// <inheritdoc/>
+    public override bool CanRead => Stream.CanRead;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => Stream.CanSeek;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => Math.Min(Stream.Length, MaxLength);
+
+    /// <inheritdoc/>
+    public override long Position { get => Stream.Position; set => Stream.Position = value; }
+
+    /// <inheritdoc/>
+    public override void Flush() => Stream.Flush();
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_position + count > MaxLength)
+            count = (int)(MaxLength - _position);
+
+        var bytesRead = Stream.Read(buffer, offset, count);
+        _position += bytesRead;
+        return bytesRead;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (offset > MaxLength && origin == SeekOrigin.Begin)
+            throw new ArgumentOutOfRangeException($"Given length value exceeds {nameof(MaxLength)} {MaxLength}");
+
+        return Stream.Seek(offset, origin);
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value)
+    {
+        if (value > MaxLength)
+            throw new ArgumentOutOfRangeException($"Given length value exceeds {nameof(MaxLength)} {MaxLength}");
+
+        Stream.SetLength(value);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException("Size limiting not available for writes.");
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Dispose the source stream synchronously
+            Stream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        // Dispose the source stream asynchronously if it supports it
+        if (Stream is IAsyncDisposable asyncDisposableStream)
+            await asyncDisposableStream.DisposeAsync();
+
+        // Dispose of unmanaged resources.
+        Dispose(false);
+
+        // Suppress finalization.
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/OwlCore.Storage.Tests/BreadthFirstRecursiveFolderTests.cs
+++ b/tests/OwlCore.Storage.Tests/BreadthFirstRecursiveFolderTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OwlCore.Storage.Memory;
+
+namespace OwlCore.Storage.Tests;
+
+[TestClass]
+public class BreadthFirstRecursiveFolderTests
+{
+    private static async Task<MemoryFolder> BuildSampleTreeAsync()
+    {
+        // root
+        var root = new MemoryFolder("root-id", "root");
+
+        // root items (in insertion order)
+        await root.CreateFileAsync("root-file");            // file
+        var a = (IModifiableFolder)await root.CreateFolderAsync("A"); // folder A
+        var b = (IModifiableFolder)await root.CreateFolderAsync("B"); // folder B
+
+        // A's children
+        await a.CreateFileAsync("A1");                      // file
+        var aa = (IModifiableFolder)await a.CreateFolderAsync("AA");   // folder
+        await a.CreateFolderAsync("AB");                    // empty folder
+
+        // AA's child
+        await aa.CreateFileAsync("AA1");                    // file
+
+        // B's child
+        await b.CreateFileAsync("B1");                      // file
+
+        return root;
+    }
+
+    private static async Task<List<IStorableChild>> CollectAsync(IAsyncEnumerable<IStorableChild> items)
+    {
+        var list = new List<IStorableChild>();
+        await foreach (var item in items)
+            list.Add(item);
+        return list;
+    }
+
+    [TestMethod]
+    public async Task Enumerates_BreadthFirst_All()
+    {
+        var root = await BuildSampleTreeAsync();
+        var bfs = new BreadthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(bfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        // Expected breadth-first traversal order (files and folders)
+        CollectionAssert.AreEqual(new[]
+        {
+            // Depth 1 (root's direct children): root-file, A, B
+            "root-file",
+            "A",
+            "B",
+            // Depth 2: A1, AA, AB, B1
+            "A1",
+            "AA",
+            "AB",
+            "B1",
+            // Depth 3: AA1
+            "AA1",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Enumerates_BreadthFirst_Files_Only()
+    {
+        var root = await BuildSampleTreeAsync();
+        var bfs = new BreadthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(bfs.GetItemsAsync(StorableType.File));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            // Depth 1
+            "root-file",
+            // Depth 2
+            "A1",
+            "B1",
+            // Depth 3
+            "AA1",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Enumerates_BreadthFirst_Folders_Only()
+    {
+        var root = await BuildSampleTreeAsync();
+        var bfs = new BreadthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(bfs.GetItemsAsync(StorableType.Folder));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            // Depth 1
+            "A",
+            "B",
+            // Depth 2
+            "AA",
+            "AB",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Respects_MaxDepth_Level1()
+    {
+        var root = await BuildSampleTreeAsync();
+        var bfs = new BreadthFirstRecursiveFolder(root)
+        {
+            MaxDepth = 1,
+        };
+
+        var items = await CollectAsync(bfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            // Only direct children of root
+            "root-file",
+            "A",
+            "B",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Respects_MaxDepth_Level2()
+    {
+        var root = await BuildSampleTreeAsync();
+        var bfs = new BreadthFirstRecursiveFolder(root)
+        {
+            MaxDepth = 2,
+        };
+
+        var items = await CollectAsync(bfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            // Depth 1
+            "root-file",
+            "A",
+            "B",
+            // Depth 2
+            "A1",
+            "AA",
+            "AB",
+            "B1",
+        }, names);
+    }
+}

--- a/tests/OwlCore.Storage.Tests/DepthFirstRecursiveFolderTests.cs
+++ b/tests/OwlCore.Storage.Tests/DepthFirstRecursiveFolderTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OwlCore.Storage.Memory;
+
+namespace OwlCore.Storage.Tests;
+
+[TestClass]
+public class DepthFirstRecursiveFolderTests
+{
+    private static async Task<MemoryFolder> BuildSampleTreeAsync()
+    {
+        // root
+        var root = new MemoryFolder("root-id", "root");
+
+        // root items (in insertion order)
+        await root.CreateFileAsync("root-file");            // file
+        var a = (IModifiableFolder)await root.CreateFolderAsync("A"); // folder A
+
+        // A's children
+        await a.CreateFileAsync("A1");                      // file
+        var aa = (IModifiableFolder)await a.CreateFolderAsync("AA");   // folder
+        await aa.CreateFileAsync("AA1");                    // file
+        await a.CreateFolderAsync("AB");                    // empty folder
+
+        var b = (IModifiableFolder)await root.CreateFolderAsync("B");  // folder B
+        await b.CreateFileAsync("B1");                      // file
+
+        return root;
+    }
+
+    private static async Task<List<IStorableChild>> CollectAsync(IAsyncEnumerable<IStorableChild> items)
+    {
+        var list = new List<IStorableChild>();
+        await foreach (var item in items)
+            list.Add(item);
+        return list;
+    }
+
+    [TestMethod]
+    public async Task Enumerates_DepthFirst_All()
+    {
+        var root = await BuildSampleTreeAsync();
+        var dfs = new DepthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(dfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        // Expected depth-first traversal order (files and folders)
+        CollectionAssert.AreEqual(new[]
+        {
+            "root-file",
+            "A",
+            "A1",
+            "AA",
+            "AA1",
+            "AB",
+            "B",
+            "B1",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Enumerates_Files_Only()
+    {
+        var root = await BuildSampleTreeAsync();
+        var dfs = new DepthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(dfs.GetItemsAsync(StorableType.File));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            "root-file",
+            "A1",
+            "AA1",
+            "B1",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Enumerates_Folders_Only()
+    {
+        var root = await BuildSampleTreeAsync();
+        var dfs = new DepthFirstRecursiveFolder(root);
+
+        var items = await CollectAsync(dfs.GetItemsAsync(StorableType.Folder));
+        var names = items.Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[]
+        {
+            "A",
+            "AA",
+            "AB",
+            "B",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Respects_MaxDepth_Level1()
+    {
+        var root = await BuildSampleTreeAsync();
+        var dfs = new DepthFirstRecursiveFolder(root)
+        {
+            MaxDepth = 1,
+        };
+
+        var items = await CollectAsync(dfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        // Depth = 1: only root-level items, no traversal into child folders
+        CollectionAssert.AreEqual(new[]
+        {
+            "root-file",
+            "A",
+            "B",
+        }, names);
+    }
+
+    [TestMethod]
+    public async Task Respects_MaxDepth_Level2()
+    {
+        var root = await BuildSampleTreeAsync();
+        var dfs = new DepthFirstRecursiveFolder(root)
+        {
+            MaxDepth = 2,
+        };
+
+        var items = await CollectAsync(dfs.GetItemsAsync(StorableType.All));
+        var names = items.Select(x => x.Name).ToArray();
+
+        // Depth = 2: includes items within first-level folders, but does not traverse into AA
+        CollectionAssert.AreEqual(new[]
+        {
+            "root-file",
+            "A",
+            "A1",
+            "AA",
+            "AB",
+            "B",
+            "B1",
+        }, names);
+    }
+}


### PR DESCRIPTION
[New]
- DepthFirstRecursiveFolder: depth-first async traversal wrapper over any IFolder with optional MaxDepth.
- BreadthFirstRecursiveFolder: breadth-first async traversal wrapper over any IFolder with optional MaxDepth.
- ItemsOverrideFolder: override a folder's GetItemsAsync by projecting its async enumerable.
- ReadOnlyCompositeFolder: present a read-only folder view materialized from a set of files.
- ParentOverrideChildFile: wrap any IFile with a custom parent, exposing it as IChildFile.
- TruncatedFile: wrap a file and cap the readable length of its underlying stream.
- TruncatedFilesFolder: wrap a folder so each file is exposed with a maximum byte length.
- TruncatedStream: stream wrapper enforcing a maximum readable length.

[Tests]
- Added traversal tests for DepthFirstRecursiveFolder and BreadthFirstRecursiveFolder covering BFS/DFS order, type filtering, and MaxDepth semantics.