### PR TITLE
Add ranged ReadText/WriteText extensions, IFile.CopyToAsync, tests

### DIFF
--- a/src/Extensions/CopyExtensions.cs
+++ b/src/Extensions/CopyExtensions.cs
@@ -85,4 +85,23 @@ public static partial class ModifiableFolderExtensions
 
         return newFile;
     }
+
+    /// <summary>
+    /// Copies the contents of the source file to the destination file.
+    /// </summary>
+    /// <param name="sourceFile">The source file to copy from.</param>
+    /// <param name="destinationFile">The destination file to copy to.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A task that represents the asynchronous copy operation.</returns>
+    public static async Task CopyToAsync(this IFile sourceFile, IFile destinationFile, CancellationToken cancellationToken = default)
+    {
+        using var sourceStream = await sourceFile.OpenStreamAsync(FileAccess.Read, cancellationToken);
+        using var destinationStream = await destinationFile.OpenStreamAsync(FileAccess.Write, cancellationToken);
+
+#if NETSTANDARD
+        await sourceStream.CopyToAsync(destinationStream);
+#elif NET5_OR_GREATER
+        await sourceStream.CopyToAsync(destinationStream, cancellationToken);
+#endif
+    }
 }

--- a/src/Extensions/FileReadExtensions.cs
+++ b/src/Extensions/FileReadExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -89,5 +92,113 @@ public static class FileReadExtensions
     {
         var bytes = await file.ReadBytesAsync(bufferSize, cancellationToken);
         return encoding.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Reads a specific range from the text file. 
+    /// </summary>
+    /// <param name="sourceFile">The file to read from.</param>
+    /// <param name="lineRange">The line range to read.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A per-line async enumerable of the read content.</returns>
+#if NETSTANDARD
+    public static async IAsyncEnumerable<string> ReadTextAsync(this IFile sourceFile, (int Start, int End) lineRange, [EnumeratorCancellation] CancellationToken cancellationToken)
+#elif NET7_OR_GREATER
+    public static async IAsyncEnumerable<string> ReadTextAsync(this IFile sourceFile, Range lineRange, [EnumeratorCancellation] CancellationToken cancellationToken)
+#endif
+    {
+        using var fileStream = await sourceFile.OpenReadAsync(cancellationToken);
+        using var streamReader = new StreamReader(fileStream);
+
+        // Fast-forward to range start
+        var currentLine = 0;
+#if NETSTANDARD
+        while (currentLine++ < lineRange.Start)
+#elif NET7_OR_GREATER
+        while (currentLine++ < lineRange.Start.Value)
+#endif
+
+        {
+#if NETSTANDARD
+            _ = await streamReader.ReadLineAsync();
+#elif NET7_OR_GREATER
+            _ = await streamReader.ReadLineAsync(cancellationToken);
+#endif
+        }
+
+        // Read to range end
+#if NETSTANDARD
+        while (currentLine++ <= lineRange.End)
+#elif NET7_OR_GREATER
+        while (currentLine++ <= lineRange.End.Value)
+#endif
+        {
+#if NETSTANDARD
+            var line = await streamReader.ReadLineAsync();
+#elif NET7_OR_GREATER
+            var line = await streamReader.ReadLineAsync(cancellationToken);
+#endif
+            if (line is not null)
+                yield return line;
+        }
+    }
+
+    /// <summary>
+    /// Reads a specific column range from each line within a line range in the text file.
+    /// </summary>
+    /// <param name="sourceFile">The file to read from.</param>
+    /// <param name="lineRange">The line range to read.</param>
+    /// <param name="columnRange">The character range within each line to return.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A per-line async enumerable of the read content.</returns>
+#if NETSTANDARD
+    public static async IAsyncEnumerable<string> ReadTextAsync(this IFile sourceFile, (int Start, int End) lineRange, (int Start, int End) columnRange, [EnumeratorCancellation] CancellationToken cancellationToken)
+#elif NET7_OR_GREATER
+    public static async IAsyncEnumerable<string> ReadTextAsync(this IFile sourceFile, Range lineRange, Range columnRange, [EnumeratorCancellation] CancellationToken cancellationToken)
+#endif
+    {
+        using var fileStream = await sourceFile.OpenReadAsync(cancellationToken);
+        using var streamReader = new StreamReader(fileStream);
+
+        // Skip to line range start
+        var currentLine = 0;
+#if NETSTANDARD
+        while (currentLine++ < lineRange.Start)
+            _ = await streamReader.ReadLineAsync();
+#elif NET7_OR_GREATER
+        while (currentLine++ < lineRange.Start.Value)
+            _ = await streamReader.ReadLineAsync(cancellationToken);
+#endif
+
+        // Take to line range end
+#if NETSTANDARD
+    while (currentLine++ <= lineRange.End)
+        {
+            var line = await streamReader.ReadLineAsync();
+            if (line is not null)
+            {
+                var start = columnRange.Start;
+                var end = columnRange.End;
+                var length = Math.Max(0, end - start);
+
+                if (start >= line.Length)
+                {
+                    yield return string.Empty;
+                }
+                else
+                {
+                    var safeLen = Math.Min(length, line.Length - start);
+                    yield return line.Substring(start, safeLen);
+                }
+            }
+        }
+#elif NET7_OR_GREATER
+        while (currentLine++ <= lineRange.End.Value)
+        {
+            var line = await streamReader.ReadLineAsync(cancellationToken);
+            if (line is not null)
+                yield return new([.. line.Skip(columnRange.Start.Value).Take(columnRange.End.Value - columnRange.Start.Value)]);
+        }
+#endif
     }
 }

--- a/src/Extensions/FileWriteExtensions.cs
+++ b/src/Extensions/FileWriteExtensions.cs
@@ -45,4 +45,121 @@ public static class FileWriteExtensions
         var bytes = encoding.GetBytes(content);
         await file.WriteBytesAsync(bytes, cancellationToken);
     }
+
+    /// <summary>
+    /// Writes only the specified line range from the provided <paramref name="content"/> into <paramref name="file"/> as UTF-8 text.
+    /// </summary>
+    /// <param name="file">The destination file to write to.</param>
+    /// <param name="content">The full text content to slice and write.</param>
+    /// <param name="lineRange">The line range (inclusive) from the content to write.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A Task representing the asynchronous write operation.</returns>
+#if NETSTANDARD
+    public static async Task WriteTextAsync(this IFile file, string content, (int Start, int End) lineRange, CancellationToken cancellationToken = default)
+#elif NET7_OR_GREATER
+    public static async Task WriteTextAsync(this IFile file, string content, Range lineRange, CancellationToken cancellationToken = default)
+#endif
+    {
+        using var writeStream = await file.OpenWriteAsync(cancellationToken);
+        using var writer = new StreamWriter(writeStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: false);
+
+        int startLine;
+        int endLineInclusive;
+#if NETSTANDARD
+        startLine = lineRange.Start;
+        endLineInclusive = lineRange.End;
+#elif NET7_OR_GREATER
+        startLine = lineRange.Start.Value;
+        endLineInclusive = lineRange.End.Value;
+#endif
+
+        foreach (var line in SliceLines(content, startLine, endLineInclusive, null, null))
+        {
+            await writer.WriteLineAsync(line);
+        }
+#if NET7_OR_GREATER
+        await writer.FlushAsync(cancellationToken);
+#else
+        await writer.FlushAsync();
+#endif
+    }
+
+    /// <summary>
+    /// Writes only the specified column range from each line within a line range from the provided <paramref name="content"/> into <paramref name="file"/> as UTF-8 text.
+    /// </summary>
+    /// <param name="file">The destination file to write to.</param>
+    /// <param name="content">The full text content to slice and write.</param>
+    /// <param name="lineRange">The line range (inclusive) from the content to write.</param>
+    /// <param name="columnRange">The character range within each line to write (end exclusive).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A Task representing the asynchronous write operation.</returns>
+#if NETSTANDARD
+    public static async Task WriteTextAsync(this IFile file, string content, (int Start, int End) lineRange, (int Start, int End) columnRange, CancellationToken cancellationToken = default)
+#elif NET7_OR_GREATER
+    public static async Task WriteTextAsync(this IFile file, string content, Range lineRange, Range columnRange, CancellationToken cancellationToken = default)
+#endif
+    {
+        using var writeStream = await file.OpenWriteAsync(cancellationToken);
+        using var writer = new StreamWriter(writeStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: false);
+
+        int startLine;
+        int endLineInclusive;
+        int startCol;
+        int endColExclusive;
+#if NETSTANDARD
+        startLine = lineRange.Start;
+        endLineInclusive = lineRange.End;
+        startCol = columnRange.Start;
+        endColExclusive = columnRange.End;
+#elif NET7_OR_GREATER
+        startLine = lineRange.Start.Value;
+        endLineInclusive = lineRange.End.Value;
+        startCol = columnRange.Start.Value;
+        endColExclusive = columnRange.End.Value;
+#endif
+
+        foreach (var line in SliceLines(content, startLine, endLineInclusive, startCol, endColExclusive))
+        {
+            await writer.WriteLineAsync(line);
+        }
+#if NET7_OR_GREATER
+        await writer.FlushAsync(cancellationToken);
+#else
+        await writer.FlushAsync();
+#endif
+    }
+
+    // Shared line/column slicer for both overloads to keep logic consistent across TFMs.
+    private static global::System.Collections.Generic.IEnumerable<string> SliceLines(string content, int startLine, int endLineInclusive, int? startColumnOrNull, int? endColumnExclusiveOrNull)
+    {
+        using var reader = new StringReader(content);
+        var current = 0;
+        string? line;
+
+        // Fast-forward to the starting line
+        while (current++ < startLine && (line = reader.ReadLine()) is not null) { }
+
+        // Emit each selected line (inclusive end)
+        while (current++ <= endLineInclusive && (line = reader.ReadLine()) is not null)
+        {
+            if (startColumnOrNull is null || endColumnExclusiveOrNull is null)
+            {
+                yield return line;
+                continue;
+            }
+
+            var startCol = startColumnOrNull.Value;
+            var endColExclusive = endColumnExclusiveOrNull.Value; // exclusive end
+
+            if (line.Length <= startCol)
+            {
+                yield return string.Empty;
+                continue;
+            }
+
+            var length = endColExclusive - startCol;
+            var safeLen = global::System.Math.Min(length, line.Length - startCol);
+            yield return line.Substring(startCol, safeLen);
+        }
+    }
 }

--- a/tests/OwlCore.Storage.Tests/FileRangeReadWriteTests.cs
+++ b/tests/OwlCore.Storage.Tests/FileRangeReadWriteTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Storage.Memory;
+
+namespace OwlCore.Storage.Tests;
+
+[TestClass]
+public class FileRangeReadWriteTests
+{
+        private static Task<IModifiableFolder> CreateRootAsync()
+                => Task.FromResult((IModifiableFolder)new MemoryFolder("root-id", "root"));
+
+    [TestMethod]
+    public async Task Read_Lines_Range_AllColumns()
+    {
+        var root = await CreateRootAsync();
+        var file = (IFile)await root.CreateFileAsync("a.txt");
+
+        var content = string.Join("\n", new[] { "L0", "L1", "L2", "L3", "L4" });
+        await file.WriteTextAsync(content, Encoding.UTF8);
+
+            var lines = await file.ReadTextAsync((1, 4), CancellationToken.None).ToListAsync();
+        CollectionAssert.AreEqual(new[] { "L1", "L2", "L3" }, lines);
+    }
+
+    [TestMethod]
+    public async Task Read_Lines_And_Columns_Range()
+    {
+        var root = await CreateRootAsync();
+        var file = (IFile)await root.CreateFileAsync("a.txt");
+
+        var content = string.Join("\n", new[] { "abcd", "efgh", "ijkl", "mnop" });
+        await file.WriteTextAsync(content, Encoding.UTF8);
+
+            var lines = await file.ReadTextAsync((1, 3), (1, 3), CancellationToken.None).ToListAsync();
+        CollectionAssert.AreEqual(new[] { "fg", "jk" }, lines);
+    }
+
+    [TestMethod]
+    public async Task Write_Lines_Range_AllColumns()
+    {
+    var root = await CreateRootAsync();
+    var dst = (IFile)await root.CreateFileAsync("dst.txt");
+
+    var content = string.Join("\n", new[] { "A0", "A1", "A2", "A3" });
+    await dst.WriteTextAsync(content, (1, 3), CancellationToken.None);
+        var output = await dst.ReadTextAsync();
+        Assert.AreEqual("A1\nA2\n", output.Replace("\r\n", "\n"));
+    }
+
+    [TestMethod]
+    public async Task Write_Lines_And_Columns_Range()
+    {
+    var root = await CreateRootAsync();
+    var dst = (IFile)await root.CreateFileAsync("dst.txt");
+
+    var content = string.Join("\n", new[] { "abcd", "efgh", "ijkl", "mnop" });
+    await dst.WriteTextAsync(content, (1, 4), (1, 3), CancellationToken.None);
+        var lines = await dst.ReadTextAsync().ConfigureAwait(false);
+    Assert.AreEqual("fg\njk\nno\n", lines.Replace("\r\n", "\n"));
+    }
+}


### PR DESCRIPTION
[New]
- FileReadExtensions.ReadTextAsync (line + column range): iterate a specific line range and slice per-line columns.
- FileWriteExtensions.WriteTextAsync (line range; line + column range): write sliced text content into a file (line end inclusive, column end exclusive).
- CopyExtensions.CopyToAsync: async file-to-file copy extension over IFile.

[Tests]
- Added range read/write tests for IFile covering line range and line + column range.