### PR TITLE
Added async-iterable relative path traversal helpers

### DIFF
--- a/src/Extensions/GetItemByRelativePathExtension.cs
+++ b/src/Extensions/GetItemByRelativePathExtension.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -75,5 +77,59 @@ public static partial class StorableExtensions
             throw new FileNotFoundException($"An item named '{nextPathPart}' was requested from the folder named '{from.Name}', but '{nextPathPart}' wasn't found in the folder.");
 
         return await GetItemByRelativePathAsync(item, string.Join(ourPathSeparator, pathParts.Skip(1)));
+    }
+
+    /// <summary>
+    /// Navigates a relative path from a starting storable without creating any items, yielding each visited node in order.
+    /// Supports '.' (no-op) and '..' (navigate to parent). Throws if a segment cannot be resolved.
+    /// </summary>
+    /// <param name="from">The starting item for traversal.</param>
+    /// <param name="relativePath">The relative path to navigate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async sequence of visited storables (parents or children), in traversal order, excluding the starting item.</returns>
+    public static async IAsyncEnumerable<IStorable> GetItemsAlongRelativePathAsync(this IStorable from, string relativePath, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (from is not IFolder && from is not IStorableChild)
+            throw new ArgumentException($"The starting item '{from.Name}' must be a folder or a child with a parent.", nameof(from));
+
+        var current = from;
+        var normalized = (relativePath ?? string.Empty).Replace('\\', '/');
+    // Split path into parts (use API available on target framework)
+#if NETSTANDARD2_0
+    var parts = normalized.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
+#else
+    var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+#endif
+
+        foreach (var raw in parts)
+        {
+            var segment = raw.Trim();
+            if (segment.Length == 0 || segment == ".")
+                continue;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (segment == "..")
+            {
+                if (current is not IStorableChild child)
+                    throw new ArgumentException($"A parent folder was requested, but '{current.Name}' is not the child of a directory.", nameof(relativePath));
+
+                var parent = await child.GetParentAsync(cancellationToken)
+                             ?? throw new ArgumentOutOfRangeException(nameof(relativePath), "A parent folder was requested, but the storable item did not return a parent.");
+
+                current = parent;
+                yield return parent;
+                continue;
+            }
+
+            if (current is not IFolder folder)
+                throw new ArgumentException($"The item '{current.Name}' is not a folder and cannot contain '{segment}'.");
+
+            var next = await folder.GetFirstByNameAsync(segment)
+                       ?? throw new FileNotFoundException($"A named item was specified in a folder, but the item wasn't found: '{segment}'", segment);
+
+            current = next;
+            yield return next;
+        }
     }
 }

--- a/src/Extensions/GetRelativePathToExtension.cs
+++ b/src/Extensions/GetRelativePathToExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +42,60 @@ public static partial class FolderExtensions
                 pathComponents.Insert(0, parent.Name);
                 await RecursiveAddParentToPathAsync(child);
             }
+        }
+    }
+
+    /// <summary>
+    /// Crawls the ancestors of <paramref name="to"/> until <paramref name="from"/> is found, yielding each item along the path
+    /// in traversal order from the child directly under <paramref name="from"/> down to <paramref name="to"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="to"/> is the same item as <paramref name="from"/>, the sequence is empty.
+    /// </remarks>
+    /// <param name="from">The folder to which the relative path is calculated.</param>
+    /// <param name="to">The target descendant item.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An async sequence of items representing the path components, excluding <paramref name="from"/>.</returns>
+    public static async IAsyncEnumerable<IStorable> GetItemsAlongRelativePathToAsync(this IFolder from, IStorableChild to, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // If the starting folder is the same as the target, nothing to traverse.
+        if (Equals(from, to) || from.Id == to.Id)
+            yield break;
+
+        // Build the chain upward: [to, parent, parent-of-parent, ...] until reaching 'from' (exclusive)
+        var chain = new List<IStorable>();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var current = to;
+        while (current is not null)
+        {
+            chain.Add(current);
+
+            var parent = await current.GetParentAsync(cancellationToken);
+            if (parent is null)
+                break;
+
+            if (parent.Id == from.Id)
+                break; // Reached the anchor; do not include 'from'
+
+            if (parent is IStorableChild parentChild)
+            {
+                current = parentChild;
+            }
+            else
+            {
+                // Parent isn't a child (e.g., a root). Stop to mirror original path behavior.
+                break;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        // Yield from the item directly under 'from' down to 'to' to match the order of the string path.
+        for (int i = chain.Count - 1; i >= 0; i--)
+        {
+            yield return chain[i];
         }
     }
 }

--- a/tests/OwlCore.Storage.Tests/RelativePathExtensionsTests.cs
+++ b/tests/OwlCore.Storage.Tests/RelativePathExtensionsTests.cs
@@ -1,4 +1,5 @@
 using OwlCore.Storage.Memory;
+using System.Linq;
 
 namespace OwlCore.Storage.Tests;
 
@@ -74,5 +75,164 @@ public class RelativePathExtensionsTests
 
         // Make sure they match
         Assert.AreEqual(relativePath, newRelativePath);
+    }
+
+    [
+        DataRow("/"),
+
+        DataRow("/a/"),
+        DataRow("/b/"),
+        DataRow("/c"),
+
+        DataRow("/a/a/"),
+        DataRow("/a/b/"),
+        DataRow("/a/c"),
+
+        DataRow("/a/a/a/"),
+        DataRow("/a/a/b/"),
+        DataRow("/a/a/c"),
+
+        DataRow("/b/a/"),
+        DataRow("/b/b/"),
+        DataRow("/b/c"),
+
+        DataRow("/b/a/a/"),
+        DataRow("/b/a/b/"),
+        DataRow("/b/a/c"),
+    ]
+    [TestMethod]
+    public async Task GetRelativePathToItems_YieldsExpectedSequence(string relativePath)
+    {
+        var target = (IStorableChild)await _rootFolder.GetItemByRelativePathAsync(relativePath);
+
+        var expectedSegments = relativePath == "/"
+            ? Array.Empty<string>()
+            : relativePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        var yielded = new List<IStorable>();
+        await foreach (var item in _rootFolder.GetItemsAlongRelativePathToAsync(target))
+        {
+            yielded.Add(item);
+        }
+
+        Assert.AreEqual(expectedSegments.Length, yielded.Count, "Yielded count should match number of path segments.");
+
+        for (int i = 0; i < expectedSegments.Length; i++)
+        {
+            Assert.AreEqual(expectedSegments[i], yielded[i].Name, $"Segment {i} name mismatch.");
+        }
+
+        if (expectedSegments.Length == 0)
+        {
+            // Root case: nothing should be yielded.
+            Assert.AreEqual(0, yielded.Count);
+        }
+        else
+        {
+            // Validate last item type matches file vs folder according to trailing slash.
+            if (relativePath.EndsWith("/"))
+                Assert.IsInstanceOfType(yielded[^1], typeof(IFolder));
+            else
+                Assert.IsInstanceOfType(yielded[^1], typeof(IFile));
+        }
+    }
+
+    [
+        DataRow("/"),
+
+        DataRow("/a/"),
+        DataRow("/b/"),
+        DataRow("/c"),
+
+        DataRow("/a/a/"),
+        DataRow("/a/b/"),
+        DataRow("/a/c"),
+
+        DataRow("/a/a/a/"),
+        DataRow("/a/a/b/"),
+        DataRow("/a/a/c"),
+
+        DataRow("/b/a/"),
+        DataRow("/b/b/"),
+        DataRow("/b/c"),
+
+        DataRow("/b/a/a/"),
+        DataRow("/b/a/b/"),
+        DataRow("/b/a/c"),
+
+        // Normalization cases
+        DataRow("/a/./b/"),
+        DataRow("\\a\\b\\c"),
+    ]
+    [TestMethod]
+    public async Task GetItemsAlongRelativePath_YieldsExpectedSequence(string relativePath)
+    {
+        var normalized = (relativePath ?? string.Empty).Replace('\\', '/');
+        var expectedSegments = normalized == "/"
+            ? Array.Empty<string>()
+            : normalized.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .Where(s => s != ".")
+                .ToArray();
+
+        var yielded = new List<IStorable>();
+    await foreach (var item in _rootFolder.GetItemsAlongRelativePathAsync(relativePath ?? string.Empty))
+        {
+            yielded.Add(item);
+        }
+
+        Assert.AreEqual(expectedSegments.Length, yielded.Count, "Yielded count should match number of path segments.");
+
+        for (int i = 0; i < expectedSegments.Length; i++)
+        {
+            Assert.AreEqual(expectedSegments[i], yielded[i].Name, $"Segment {i} name mismatch.");
+        }
+
+        if (expectedSegments.Length == 0)
+        {
+            // Root case: nothing should be yielded.
+            Assert.AreEqual(0, yielded.Count);
+        }
+        else
+        {
+            // Validate last item type matches file vs folder according to trailing slash of the normalized path.
+            if (normalized.EndsWith("/"))
+                Assert.IsInstanceOfType(yielded[^1], typeof(IFolder));
+            else
+                Assert.IsInstanceOfType(yielded[^1], typeof(IFile));
+        }
+    }
+
+    [TestMethod]
+    public async Task GetItemsAlongRelativePath_SupportsParentTraversal()
+    {
+        // Start at /a/a/
+        var start = (IStorableChild)await _rootFolder.GetItemByRelativePathAsync("/a/a/");
+
+        // Go up to /a then to file /a/c
+        var yielded = new List<IStorable>();
+        await foreach (var item in start.GetItemsAlongRelativePathAsync("../c"))
+        {
+            yielded.Add(item);
+        }
+
+        Assert.AreEqual(2, yielded.Count);
+        Assert.AreEqual("a", yielded[0].Name);
+        Assert.AreEqual("c", yielded[1].Name);
+        Assert.IsInstanceOfType(yielded[0], typeof(IFolder));
+        Assert.IsInstanceOfType(yielded[1], typeof(IFile));
+
+        // Multiple parents: from /b/a/b/ to ../../c -> /b/c
+        start = (IStorableChild)await _rootFolder.GetItemByRelativePathAsync("/b/a/b/");
+        yielded.Clear();
+        await foreach (var item in start.GetItemsAlongRelativePathAsync("../../c"))
+        {
+            yielded.Add(item);
+        }
+
+        Assert.AreEqual(2, yielded.Count);
+        Assert.AreEqual("b", yielded[0].Name);
+        Assert.AreEqual("c", yielded[1].Name);
+        Assert.IsInstanceOfType(yielded[0], typeof(IFolder));
+        Assert.IsInstanceOfType(yielded[1], typeof(IFile));
     }
 }


### PR DESCRIPTION
[Improvements]
Added StorableExtensions.GetItemsAlongRelativePathAsync: navigates a relative path from any IStorable, yielding each visited node in order (supports '.', '..', and normalizes path separators).

Added FolderExtensions.GetItemsAlongRelativePathToAsync: yields items along the path from a source IFolder to a descendant IStorableChild in traversal order.