### PR TITLE
Fix CreateByRelativePathCoreAsync file-tail detection for StorableType.Folder

### DIFF
--- a/src/Extensions/CreateRelativeStorageExtensions.cs
+++ b/src/Extensions/CreateRelativeStorageExtensions.cs
@@ -124,7 +124,11 @@ public static class CreateRelativeStorageExtensions
         }
         else
         {
-            for (int i = 0; i < parts.Length; i++)
+            // Ignore file-like tail when creating folder path
+            var lastLooksFile = LooksLikeFileTail(parts, hasTrailingSlash);
+            var effectiveLength = lastLooksFile ? Math.Max(0, parts.Length - 1) : parts.Length;
+            
+            for (int i = 0; i < effectiveLength; i++)
             {
                 var segment = parts[i].Trim();
                 if (segment.Length == 0 || segment == ".")


### PR DESCRIPTION
## Summary

Fixes `CreateByRelativePathCoreAsync` file-tail detection for `StorableType.Folder` to prevent treating file paths like `path/to/file.txt` as folder paths during folder creation.

## Root Cause

The folder creation loop in `CreateByRelativePathCoreAsync` iterated over ALL path segments without checking if the last segment represented a file (indicated by dots suggesting extensions). This caused paths like `assets/images/hero.png` to create a folder named `hero.png`.

## Fix

Added file-tail detection using existing `LooksLikeFileTail` helper:
- Checks if last segment looks like a file (has dots, no trailing slash)
- Reduces effective loop length to exclude file-like tail from folder creation
- Preserves existing behavior for paths with trailing slashes or no file-like segments

## Validation

- ✅ **Blog Generator Materialization**: Fix validated during PostPageFolder refactor (Nov 9, 2025)
- ✅ **Runtime Behavior**: Template asset copying now succeeds (previously stalled creating `hero.png` folder)
- ✅ **Root Cause Confirmed**: Log analysis showed malformed paths like `/C:\/Users/.../images/hero.png` before fix
